### PR TITLE
Fixed the bug with CUDA 7.0 BOOST 1.5.x C++11, see http://stackoverfl…

### DIFF
--- a/tests/test_gpu_deconvolve_single_stepped.cu
+++ b/tests/test_gpu_deconvolve_single_stepped.cu
@@ -1,5 +1,16 @@
 #define BOOST_TEST_DYN_LINK
 #define BOOST_TEST_MODULE GPU_DECONVOLVE_SINGLE_STEPPED
+
+// check boost 1.5x and cuda version 7.0 due to bug in c++11 compilation mode
+// http://stackoverflow.com/questions/31940457/make-nvcc-output-traces-on-compile-error
+#include <boost/predef.h>
+#include <cuda.h>
+#if defined(BOOST_COMP_GNUC) && BOOST_COMP_GNUC >= BOOST_VERSION_NUMBER(4,7,0) \
+   || defined(CUDA_VERSION) && CUDA_VERSION == 7000 \
+   || defined(BOOST_VERSION) && BOOST_VERSION >= BOOST_VERSION_NUMBER(1,5,0)
+ #include <boost/utility/result_of.hpp>
+#endif
+
 #include "boost/test/unit_test.hpp"
 #include <functional>
 #include <algorithm>
@@ -15,6 +26,9 @@
 #include "cpu_kernels.h"
 #include "test_algorithms.hpp"
 #include "cuda_kernels.cuh"
+
+#define QUOTE(str) #str
+#define STR(str) QUOTE(str)
 
 using namespace multiviewnative;
 

--- a/tests/test_gpu_deconvolve_single_stepped.cu
+++ b/tests/test_gpu_deconvolve_single_stepped.cu
@@ -27,9 +27,6 @@
 #include "test_algorithms.hpp"
 #include "cuda_kernels.cuh"
 
-#define QUOTE(str) #str
-#define STR(str) QUOTE(str)
-
 using namespace multiviewnative;
 
 BOOST_AUTO_TEST_SUITE(cpu_vs_gpu)


### PR DESCRIPTION
…ow.com/questions/31940457/make-nvcc-output-traces-on-compile-error.
